### PR TITLE
poseidon: create a less-alloc heavy version of poseidon

### DIFF
--- a/ff/element.go
+++ b/ff/element.go
@@ -721,6 +721,34 @@ func (z *Element) SetBytes(e []byte) *Element {
 	return z
 }
 
+// SetBytesLessMod sets the element while assuming the 
+// represented bytes is less than the group modulus.
+// If you are unsure if the input is < q, use SetBytes
+func (z *Element) SetBytesLessMod(e []byte) *Element {
+	z.SetZero()
+	if len(e)/8 > len(z) {
+		panic("not less than modulus")
+	}
+	limb := 3
+	for i := len(e)-1; i > 0; i-= 8 {
+		start := i - 8 
+		if start < 0 {
+			start = 0
+		}
+		z[limb] = toUint64(e[start:i])
+		limb--
+	}
+	return z.ToMont()
+}
+
+func toUint64(b []byte) uint64 {
+	var ret uint64
+	for i := len(b) - 1; i > 0; i-- {
+		ret |= uint64(b[i]) << (8 * (len(b)-1-i))
+	}
+	return ret
+}
+
 // SetBigInt sets z to v (regular form) and returns z in Montgomery form
 func (z *Element) SetBigInt(v *big.Int) *Element {
 	z.SetZero()

--- a/ff/element.go
+++ b/ff/element.go
@@ -729,15 +729,12 @@ func (z *Element) SetBytesLessMod(e []byte) *Element {
 	if len(e)/8 > len(z) {
 		panic("not less than modulus")
 	}
-	limb := 3
-	for i := len(e)-1; i > 0; i-= 8 {
-		start := i - 8 
-		if start < 0 {
-			start = 0
-		}
-		z[limb] = toUint64(e[start:i])
-		limb--
-	}
+	slice := make([]byte, Limbs * 8)
+	copy(slice[(Limbs * 8)-len(e):], e)
+	z[3] = toUint64(slice[0:8])
+	z[2] = toUint64(slice[7:16])
+	z[1] = toUint64(slice[15:24])
+	z[0] = toUint64(slice[23:32])
 	return z.ToMont()
 }
 

--- a/poseidon/poseidon.go
+++ b/poseidon/poseidon.go
@@ -45,20 +45,18 @@ func ark(state, c []*ff.Element, it int) {
 }
 
 // mix returns [[matrix]] * [vector]
-func mix(state []*ff.Element, t int, m [][]*ff.Element) []*ff.Element {
-	mul := zero()
-	newState := make([]*ff.Element, t)
-	for i := 0; i < t; i++ {
-		newState[i] = zero()
-	}
+// while utilizing the scratch space to save on allocations
+func mixWithScratch(state []*ff.Element, m [][]*ff.Element, scratch []*ff.Element) []*ff.Element {
 	for i := 0; i < len(state); i++ {
-		newState[i].SetUint64(0)
+		scratch[i].SetZero()
 		for j := 0; j < len(state); j++ {
-			mul.Mul(m[j][i], state[j])
-			newState[i].Add(newState[i], mul)
+			scratch[i].Add(scratch[i], new(ff.Element).Mul(m[j][i], state[j]))
 		}
 	}
-	return newState
+	for i := 0; i < len(state); i++ {
+		state[i].Set(scratch[i])
+	}
+	return state
 }
 
 // HashWithState computes the Poseidon hash for the given inputs and initState
@@ -68,6 +66,66 @@ func HashWithState(inpBI []*big.Int, initState *big.Int) (*big.Int, error) {
 		return nil, err
 	}
 	return res[0], nil
+}
+
+// OBS: assumes scratch and state are of equal length
+func hashElements(state []*ff.Element, scratch []*ff.Element) []*ff.Element {
+	t := len(state)
+	nRoundsF := NROUNDSF
+	nRoundsP := NROUNDSP[t-2]
+	C := c.c[t-2]
+	S := c.s[t-2]
+	M := c.m[t-2]
+	P := c.p[t-2]
+
+	ark(state, C, 0)
+
+	for i := 0; i < nRoundsF/2-1; i++ {
+		exp5state(state)
+		ark(state, C, (i+1)*t)
+		state = mixWithScratch(state, M, scratch)
+	}
+	exp5state(state)
+	ark(state, C, (nRoundsF/2)*t)
+	state = mixWithScratch(state, P, scratch)
+	newState0 := zero()
+
+	for i := 0; i < nRoundsP; i++ {
+		exp5(state[0])
+		state[0].Add(state[0], C[(nRoundsF/2+1)*t+i])
+
+		newState0.SetZero()
+		for j := 0; j < len(state); j++ {
+			newState0.Add(newState0, new(ff.Element).Mul(S[(t*2-1)*i+j], state[j]))
+		}
+
+		for k := 1; k < t; k++ {
+			state[k] = state[k].Add(state[k], new(ff.Element).Mul(state[0], S[(t*2-1)*i+t+k-1]))
+		}
+		state[0].Set(newState0)
+	}
+
+	for i := 0; i < nRoundsF/2-1; i++ {
+		exp5state(state)
+		ark(state, C, (nRoundsF/2+1)*t+nRoundsP+i*t)
+		state = mixWithScratch(state, M, scratch)
+	}
+	exp5state(state)
+	state = mixWithScratch(state, M, scratch)
+	return state
+}
+
+// OBS: assumes nOuts = 1
+// assumes the last element of the state is the initState
+// assumes scratch and state are of equal length
+func hashWithStateExBytes(state []*ff.Element, scratch []*ff.Element) (*ff.Element, error) {
+	if len(state) == 1 || len(state)-1 > len(NROUNDSP) {
+		return nil, fmt.Errorf("invalid inputs length %d, max %d", len(state), len(NROUNDSP))
+	}
+
+	state = hashElements(state, scratch)
+
+	return state[0], nil
 }
 
 func HashWithStateEx(inpBI []*big.Int, initState *big.Int, nOuts int) ([]*big.Int, error) {
@@ -83,13 +141,6 @@ func HashWithStateEx(inpBI []*big.Int, initState *big.Int, nOuts int) ([]*big.In
 	}
 	inp := utils.BigIntArrayToElementArray(inpBI)
 
-	nRoundsF := NROUNDSF
-	nRoundsP := NROUNDSP[t-2]
-	C := c.c[t-2]
-	S := c.s[t-2]
-	M := c.m[t-2]
-	P := c.p[t-2]
-
 	state := make([]*ff.Element, t)
 	if !utils.CheckBigIntInField(initState) {
 		return nil, errors.New("initState values not inside Finite Field")
@@ -98,43 +149,12 @@ func HashWithStateEx(inpBI []*big.Int, initState *big.Int, nOuts int) ([]*big.In
 	state[0] = ff.NewElement().SetBigInt(initState)
 	copy(state[1:], inp)
 
-	ark(state, C, 0)
-
-	for i := 0; i < nRoundsF/2-1; i++ {
-		exp5state(state)
-		ark(state, C, (i+1)*t)
-		state = mix(state, t, M)
-	}
-	exp5state(state)
-	ark(state, C, (nRoundsF/2)*t)
-	state = mix(state, t, P)
-
-	mul := zero()
-	for i := 0; i < nRoundsP; i++ {
-		exp5(state[0])
-		state[0].Add(state[0], C[(nRoundsF/2+1)*t+i])
-
-		mul.SetZero()
-		newState0 := zero()
-		for j := 0; j < len(state); j++ {
-			mul.Mul(S[(t*2-1)*i+j], state[j])
-			newState0.Add(newState0, mul)
-		}
-
-		for k := 1; k < t; k++ {
-			mul.SetZero()
-			state[k] = state[k].Add(state[k], mul.Mul(state[0], S[(t*2-1)*i+t+k-1]))
-		}
-		state[0] = newState0
+	scratch := make([]*ff.Element, len(state))
+	for i := 0; i < len(scratch); i++ {
+		scratch[i] = zero()
 	}
 
-	for i := 0; i < nRoundsF/2-1; i++ {
-		exp5state(state)
-		ark(state, C, (nRoundsF/2+1)*t+nRoundsP+i*t)
-		state = mix(state, t, M)
-	}
-	exp5state(state)
-	state = mix(state, t, M)
+	state = hashElements(state, scratch)
 
 	r := make([]*big.Int, nOuts)
 	for i := 0; i < nOuts; i++ {
@@ -159,6 +179,66 @@ func HashEx(inpBI []*big.Int, nOuts int) ([]*big.Int, error) {
 // HashBytes returns a sponge hash of a msg byte slice split into blocks of 31 bytes
 func HashBytes(msg []byte) (*big.Int, error) {
 	return HashBytesX(msg, spongeInputs)
+}
+
+// HashBytesXLessAlloc returns a sponge hash of a msg byte slice split into blocks of 31 bytes.
+// uses less allocations than the original implementation.
+func HashBytesXLessAlloc(msg []byte, frameSize int) ([]byte, error) {
+	if frameSize < 2 || frameSize > 16 {
+		return nil, errors.New("incorrect frame size")
+	}
+
+	state := make([]*ff.Element, frameSize+1)   // one additional item for initState, always 0
+	scratch := make([]*ff.Element, frameSize+1) // Scratch space to reduce allocations
+	for i := 0; i < len(state); i++ {
+		state[i] = new(ff.Element)
+		scratch[i] = new(ff.Element)
+	}
+
+	dirty := false
+	currentHash := new(ff.Element)
+
+	k := 0
+	for i := 0; i < len(msg)/spongeChunkSize; i++ {
+		dirty = true
+		state[k].SetBytesLessMod(msg[spongeChunkSize*i : spongeChunkSize*(i+1)])
+		if k == frameSize-1 {
+			hash, err := hashWithStateExBytes(state, scratch)
+			if err != nil {
+				return nil, err
+			}
+			currentHash.Set(hash)
+			dirty = false
+			state[0].Set(hash)
+			for j := 1; j < len(state); j++ {
+				state[j].SetZero()
+			}
+			k = 1
+		} else {
+			k++
+		}
+	}
+
+	if len(msg)%spongeChunkSize != 0 {
+		// the last chunk of the message is less than 31 bytes
+		// zero padding it, so that 0xdeadbeaf becomes
+		// 0xdeadbeaf000000000000000000000000000000000000000000000000000000
+		var buf [spongeChunkSize]byte
+		copy(buf[:], msg[(len(msg)/spongeChunkSize)*spongeChunkSize:])
+		state[k].SetBytesLessMod(buf[:])
+	}
+
+	if dirty {
+		// we haven't hashed something in the main sponge loop and need to do hash here
+		hash, err := hashWithStateExBytes(state, scratch)
+		if err != nil {
+			return nil, err
+		}
+		currentHash.Set(hash)
+	}
+
+	hash := currentHash.Bytes()
+	return hash[:], nil
 }
 
 // HashBytesX returns a sponge hash of a msg byte slice split into blocks of 31 bytes

--- a/poseidon/poseidon_test.go
+++ b/poseidon/poseidon_test.go
@@ -1,6 +1,8 @@
 package poseidon
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -598,5 +600,33 @@ func BenchmarkPoseidonHash16Inputs(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_, _ = Hash(bigArray16)
+	}
+}
+
+func BenchmarkPoseidonHash(b *testing.B) {
+	input := make([]byte, 5*1024*1024)
+	rand.Read(input)
+	for i := 0; i < b.N; i++ {
+		Sum(input)
+		Sum(input)
+		Sum(input)
+	}
+}
+
+func BenchmarkPoseidonHash2(b *testing.B) {
+	input := make([]byte, 5*1024*1024)
+	rand.Read(input)
+	for i := 0; i < b.N; i++ {
+		HashBytesXLessAlloc(input, spongeInputs)
+		HashBytesXLessAlloc(input, spongeInputs)
+		HashBytesXLessAlloc(input, spongeInputs)
+	}
+}
+
+func BenchmarkSHA(b *testing.B) {
+	input := make([]byte, 50*1024*1024)
+	rand.Read(input)
+	for i := 0; i < b.N; i++ {
+		sha256.Sum256(input)
 	}
 }

--- a/poseidon/poseidon_test.go
+++ b/poseidon/poseidon_test.go
@@ -1,6 +1,7 @@
 package poseidon
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -8,6 +9,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/iden3/go-iden3-crypto/ff"
 	"github.com/iden3/go-iden3-crypto/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -620,6 +622,28 @@ func BenchmarkPoseidonHash2(b *testing.B) {
 		HashBytesXLessAlloc(input, spongeInputs)
 		HashBytesXLessAlloc(input, spongeInputs)
 		HashBytesXLessAlloc(input, spongeInputs)
+	}
+}
+
+func TestLessAlloc(t *testing.T) {
+	inputA := make([]byte, 5*1024*1024)
+	rand.Read(inputA)
+
+	a := Sum(inputA)
+	b, _ := HashBytesXLessAlloc(inputA, 16)
+	if !bytes.Equal(a, b) {
+		t.Fatalf("a: %x b: %x", a, b)
+	}
+}
+
+func TestSetBytesLessAlloc(t *testing.T) {
+	input := make([]byte, 31)
+	rand.Read(input)
+
+	a := ff.NewElement().SetBytes(input)
+	b := ff.NewElement().SetBytesLessMod(input)
+	if a.Cmp(b) != 0 {
+		t.Fatalf("input %#v a %#v b %#v", input, a.Bytes(), b.Bytes())
 	}
 }
 


### PR DESCRIPTION
Draft PR to reduce allocs of poseidon

Following benchmarks for hashing a five megabyte array show the improvement quite nicely:
```
BenchmarkPoseidonHash-8   	       1	4984923109 ns/op	364910392 B/op	 8963662 allocs/op
BenchmarkPoseidonHash2-8   	       1	4473422768 ns/op	 5246544 B/op	      12 allocs/op
```

The number of allocations are now independent of the size of the input 